### PR TITLE
User creation password

### DIFF
--- a/charts/ontopic-suite/templates/jobs/users.yaml
+++ b/charts/ontopic-suite/templates/jobs/users.yaml
@@ -19,7 +19,7 @@ metadata:
     helm.sh/hook-weight: "-2"
 rules:
   - apiGroups: [""]
-    resourceNames: ["password-file-db"]
+    resourceNames: ["password-file-db", "password-db-users"]
     resources: ["secrets"]
     verbs: ["delete"]
 ---
@@ -94,13 +94,16 @@ spec:
         - "sh"
         - "-c"
         - >-
-            NAME="password-db-users";
-            FILE="/mnt/secret/${NAME}";
-            echo {{ printf "{\"users\": %s}" (.Values.users.list | toJson) | quote }} > "${FILE}";
-            if [ -f "${FILE}" ]; then
-              kubectl delete secret "${NAME}";
-              kubectl create secret generic "${NAME}" --from-file=users=${FILE};
-            fi;
+            NAME="password-db-users"
+            FILE="/mnt/secret/${NAME}"
+            printf '%s' {{- printf "{\"users\": %s}" (.Values.users.list | toJson) | toJson }} > "$FILE"
+            if [ -f "$FILE" ]; then
+              kubectl delete secret "$NAME" --ignore-not-found
+              kubectl create secret generic "$NAME" --from-file=users="$FILE"
+            else
+              echo "Error: File $FILE was not created"
+              exit 1
+            fi
             exit 0
         volumeMounts:
         - name: secret
@@ -168,7 +171,7 @@ spec:
             FILE="/mnt/secret/password-file-db";
             NAME="password-file-db";
             if [ -f "$FILE" ]; then
-              kubectl delete secret $NAME;
+              kubectl delete secret $NAME --ignore-not-found;
               kubectl create secret generic $NAME --from-file=$NAME=$FILE;
             fi;
             exit 0

--- a/charts/ontopic-suite/templates/jobs/users.yaml
+++ b/charts/ontopic-suite/templates/jobs/users.yaml
@@ -93,16 +93,16 @@ spec:
         command:
         - "sh"
         - "-c"
-        - >-
-            NAME="password-db-users"
-            FILE="/mnt/secret/${NAME}"
-            printf '%s' {{- printf "{\"users\": %s}" (.Values.users.list | toJson) | toJson }} > "$FILE"
+        - |
+            NAME="password-db-users";
+            FILE="/mnt/secret/${NAME}";
+            printf '%s' {{- printf "{\"users\": %s}" (.Values.users.list | toJson) | toJson }} > "$FILE";
             if [ -f "$FILE" ]; then
-              kubectl delete secret "$NAME" --ignore-not-found
-              kubectl create secret generic "$NAME" --from-file=users="$FILE"
+              kubectl delete secret "$NAME" --ignore-not-found;
+              kubectl create secret generic "$NAME" --from-file=users="$FILE";
             else
-              echo "Error: File $FILE was not created"
-              exit 1
+              echo "Error: File $FILE was not created";
+              exit 1;
             fi
             exit 0
         volumeMounts:
@@ -167,7 +167,7 @@ spec:
         command:
         - "sh"
         - "-c"
-        - >-
+        - |
             FILE="/mnt/secret/password-file-db";
             NAME="password-file-db";
             if [ -f "$FILE" ]; then

--- a/charts/ontopic-suite/values.yaml
+++ b/charts/ontopic-suite/values.yaml
@@ -384,12 +384,16 @@ users:
       groups:
         - developers
         - admin
+      roles:
+        - ots-admin
     - username: test
       password: "$apr1$C."
       email: test@email.it
       fullname: Test
       groups:
         - developers
+      roles:
+        - ots-project-creator
 
 # Configure the PostgreSQL subchart
 postgresql:

--- a/samples/users.json
+++ b/samples/users.json
@@ -4,19 +4,25 @@
       "username": "admin",
       "password": "$aprBe1/",
       "email": "test@email.it",
-      "fullname": "test",
+      "fullname": "Admin",
       "groups": [
         "developers",
         "admin"
+      ],
+      "roles": [
+        "ots-admin"
       ]
     },
     {
       "username": "test",
       "password": "$apr1$C.",
       "email": "test@email.it",
-      "fullname": "test",
+      "fullname": "Test",
       "groups": [
         "developers"
+      ],
+      "roles": [
+        "ots-project-creator"
       ]
     }
   ]

--- a/values.example.yaml
+++ b/values.example.yaml
@@ -40,12 +40,16 @@ users:
       groups:
         - developers
         - admin
+      roles:
+        - ots-admin
     - username: test
       password: "$apr1$C."
       email: test@email.it
       fullname: Test
       groups:
         - developers
+      roles:
+        - ots-project-creator
 
 # Configure the PostgreSQL subchart
 postgresql:


### PR DESCRIPTION
The job responsible for creating the users was incorrectly interpreting the character `$` in the default password as a shell variable.

Also the provided default users were missing the `roles` list.